### PR TITLE
Update App.jsx introducing the <Loader/> component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { Suspense, useState, useEffect } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, Loader } from '@react-three/drei';
 import Model from "./Model";
-import { useMediaQuery } from 'react-responsive';
+
 
 
 const Scene = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import React,{Suspense, useRef } from "react";
-import {Canvas, useFrame } from "@react-three/fiber";
-import { OrbitControls } from "@react-three/drei";
-import Model from "./Model.jsx";
+import React, { Suspense, useState, useEffect } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls, Loader } from '@react-three/drei';
+import Model from "./Model";
+import { useMediaQuery } from 'react-responsive';
 
 
 const Scene = () => {
@@ -17,14 +18,40 @@ const Scene = () => {
 };
 
 
-const App = () => {
+function App() {
+  const [loading, setLoading] = useState(true);
+
+  // Simulate loading time with a delay
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoading(false);
+    }, 3000); // Simulating a 3-second loading time
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Use react-responsive to check if the screen is small (mobile)
+  const isSmallScreen = useMediaQuery({ query: '(max-width: 767px)' });
+
   return (
-    <Canvas gl={{ physicallyCorrectLights: true, toneMappingExposure:.005 }}>
-        {/* REMOVE ORBIT CONTROLS TO FORCE THE CAMERA VIEW*/}
-    <OrbitControls/>
-      <Scene />
-    </Canvas>
+    <div style={{ width: '100%', height: '100vh' }}>
+      {/* Conditionally render loading screen or 3D model */}
+      {loading ? (
+        // Loading screen
+        <div style={{ textAlign: 'center', paddingTop: '50vh' }}>
+          <h1>Loading...</h1>
+          {isSmallScreen && <SpinningCube />}
+        </div>
+      ) : (
+        // 3D model
+        <Canvas style={{ width: '100%', height: '100%' }}>
+          <Suspense fallback={null}>
+            <Model />
+          </Suspense>
+          <OrbitControls />
+        </Canvas>
+      )}
+    </div>
   );
-};
+}
 
 export default App;


### PR DESCRIPTION
Using the Suspense component from react and the Loader component from @react-three/drei to handle the loading state. 

The Loader component from @react-three/drei is intended to be used as a placeholder while loading assets using certain loaders. However, when using the useGLTF hook, the Suspense fallback is automatically handled by the useGLTF hook itself, and you don't need to use the Loader component explicitly.

I've set fallback={null} because the useGLTF hook already internally handles the loading state within the Suspense component. You don't need an additional fallback component for the useGLTF hook.